### PR TITLE
sans-play/battery-life

### DIFF
--- a/android/src/main/java/org/whispersystems/signalservice/api/util/RealtimeSleepTimer.java
+++ b/android/src/main/java/org/whispersystems/signalservice/api/util/RealtimeSleepTimer.java
@@ -10,9 +10,7 @@ import android.os.Build;
 import android.os.SystemClock;
 import android.util.Log;
 
-import org.whispersystems.signalservice.api.util.SleepTimer;
-
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 /**
  * A sleep timer that is based on elapsed realtime, so
@@ -21,24 +19,29 @@ import java.util.concurrent.TimeUnit;
  */
 public class RealtimeSleepTimer implements SleepTimer {
   private static final String TAG = RealtimeSleepTimer.class.getSimpleName();
+  private static ConcurrentSkipListSet<Integer> actionIdList = new ConcurrentSkipListSet<>();
 
-  private final AlarmReceiver alarmReceiver;
   private final Context context;
 
   public RealtimeSleepTimer(Context context) {
     this.context = context;
-    alarmReceiver = new RealtimeSleepTimer.AlarmReceiver();
   }
 
   @Override
   public void sleep(long millis) {
-    context.registerReceiver(alarmReceiver,
-                             new IntentFilter(AlarmReceiver.WAKE_UP_THREAD_ACTION));
+    final AlarmReceiver alarmReceiver = new RealtimeSleepTimer.AlarmReceiver();
+    int actionId = 0;
+    while (!actionIdList.add(actionId)){
+      actionId++;
+    }
+    try {
+      context.registerReceiver(alarmReceiver,
+             new IntentFilter(AlarmReceiver.WAKE_UP_THREAD_ACTION + "." + actionId));
 
-    final long startTime = System.currentTimeMillis();
-    alarmReceiver.setAlarm(millis);
+      final long startTime = System.currentTimeMillis();
+      alarmReceiver.setAlarm(millis, AlarmReceiver.WAKE_UP_THREAD_ACTION + "." + actionId);
 
-    while (System.currentTimeMillis() - startTime < millis) {
+      while (System.currentTimeMillis() - startTime < millis) {
         try {
           synchronized (this) {
             wait(millis - System.currentTimeMillis() + startTime);
@@ -46,16 +49,20 @@ public class RealtimeSleepTimer implements SleepTimer {
         } catch (InterruptedException e) {
           Log.w(TAG, e);
         }
+      }
+      context.unregisterReceiver(alarmReceiver);
+    } catch(Exception e) {
+      Log.w(TAG, "Exception during sleep ...",e);
+    }finally {
+      actionIdList.remove(actionId);
     }
-
-    context.unregisterReceiver(alarmReceiver);
   }
 
   private class AlarmReceiver extends BroadcastReceiver {
     private static final String WAKE_UP_THREAD_ACTION = "org.whispersystems.signalservice.api.util.RealtimeSleepTimer.AlarmReceiver.WAKE_UP_THREAD";
 
-    private void setAlarm(long millis) {
-      final Intent        intent        = new Intent(WAKE_UP_THREAD_ACTION);
+    private void setAlarm(long millis, String action) {
+      final Intent        intent        = new Intent(action);
       final PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, 0);
       final AlarmManager  alarmManager  = (AlarmManager)context.getSystemService(Context.ALARM_SERVICE);
 


### PR DESCRIPTION
This code is by @theBoatman, and is part of the ongoing https://github.com/signalapp/libsignal-service-java/pull/70 PR.  The primary purpose is to reduce IllegalArgumentException every few seconds in android handsets where google playServices have been completely removed and signalapp during registration has fallen back into websocket-only-mode (non-firebase / non-gcm notifications).  There are some additional patches that would be layered on top of this one, eventually, related to dangling websockets / etc.  See related PR#62 by @dpapavas.  

The point of adding this into sigGesT is to gain additional debuglogs which show the behavior of stock signalapp *side by side* with the behavior of sigGesT-with-realtimeSleepTimer-fix, and further demonstrate that A) battery life utilization improves on sans-playSvcs handsets, while also B) there are no undesired side-effects on handset WITH playSvcs.  Please upload debuglogs from **both** stock signalapp and **also** the sigGesT apk into this thread for analysis == https://community.signalusers.org/t/call-for-testing-fixing-realtimesleeptimer-to-work-in-concurrent-threads/7189  Discussion and critiques might belong over here, if you have anything more detailed to talk about == https://community.signalusers.org/t/very-high-battery-drain-on-4-34-8-without-google-play-services/6536